### PR TITLE
Cross-compile for Scala 2.10, 2.11 and 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,13 @@
+organization := "org.docopt"
+name := "docopt"
+version := "0.1-SNAPSHOT"
+
+scalaVersion := "2.10.7"
+
+crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7")
+
+libraryDependencies ++= Seq(
+  "org.scalactic" %% "scalactic" % "3.0.0",
+  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+)
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
As most of the Scala users now use Scala 2.12, it only
makes sense to support it. For those stuck with older
versions, Scala 2.11 and 2.10 is also supported.

As Maven doesn't have a nice way to support cross-compilation
for Scala, I have done it in SBT, with keeping the maven build
around.